### PR TITLE
Nahrazeno var / let

### DIFF
--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -66,7 +66,7 @@ export const canvasSize : Size = {width: width, height: width/ratio};
  * Veškerý seznam grafik
  * @type Graphic[]
  */
-export var graphics : Graphic[] = [];
+export let graphics : Graphic[] = [];
 
 /**
  * Setter pro globální seznam grafik
@@ -80,13 +80,13 @@ export function setGraphics(g : Graphic[]){
  * Kontext pro kreslení na plátno
  * @type CanvasRenderingContext2D
  */
-export var ctx : CanvasRenderingContext2D;
+export let ctx : CanvasRenderingContext2D;
 
 const keys = ["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"]
 
-var playStatus = false;
-var dragStartPosition : Position | null = null;
-var selectedGraphic : Graphic | null = null;
+let playStatus = false;
+let dragStartPosition : Position | null = null;
+let selectedGraphic : Graphic | null = null;
 
 /**
  * Komponenta Canvas

--- a/src/models/Robot.tsx
+++ b/src/models/Robot.tsx
@@ -175,7 +175,7 @@ export class Robot extends Graphic {
      * @returns {Robot} Robot s novou pozicí
      */
     move(walls : Wall[]) : Robot {
-        var newRobot = {...this, position : {x: this.position.x + this.movement.dx, y: this.position.y + this.movement.dy}};
+        let newRobot = {...this, position : {x: this.position.x + this.movement.dx, y: this.position.y + this.movement.dy}};
         newRobot.boundingRect = getBoundingRect(newRobot.position, newRobot.size);
         //pokud nastane kolize, tak ho nemenim
         if (walls.some(w => this.isCollision(w,newRobot))){

--- a/src/utils/StorageLogic.tsx
+++ b/src/utils/StorageLogic.tsx
@@ -49,7 +49,7 @@ export function loadData(id : number){
         return;
     }
     const graphicsToSave = JSON.parse(data) as IGraphicSave[];
-    var finalData : Graphic[] = [];
+    let finalData : Graphic[] = [];
     graphicsToSave.forEach(g => {
         switch(g.type){
             case GraphicType.Wall:


### PR DESCRIPTION
Nepoužívejte klíčové slovo var, používejte raději let. var má globální scope, tedy je velmi jednoduché si vytvořit stejně pojmenovanou proměnnou, ale ve skutečnosti se tyto dvě proměnné budou přepisovat navzájem a to povede k těžko odhlaitelným bugům zejména u větších projektů. To se s let stát nemůže. var je v JS prakticky už jen z důvodů zpětné kompatibilty, proto doporučuji přidat si také toto eslint pravidlo https://eslint.org/docs/latest/rules/no-var